### PR TITLE
feat: skeleton of system lib probes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,9 +8,11 @@ version = "0.1.0"
 dependencies = [
  "camino",
  "cargo_metadata",
+ "pkg-config",
  "serde",
  "serde_json",
  "thiserror",
+ "vcpkg",
 ]
 
 [[package]]
@@ -50,6 +52,12 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "proc-macro2"
@@ -151,3 +159,9 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,5 @@ thiserror = "1.0.58"
 cargo_metadata = "0.18.1"
 serde = { version = "1.0.198", features = ["derive"] }
 serde_json = "1.0.116"
+pkg-config = "0.3.30"
+vcpkg = "0.2.15"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,16 +118,3 @@ enum VendoredSource {
         path: Utf8PathBuf,
     },
 }
-
-// |ctx: VendoredBuildContext| -> Result<(), BuildFailure>
-// struct VendoredBuildContext {
-//     source_path: Utf8PathBuf,
-// }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {}
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,58 @@ impl BuildKit {
 
         Ok(BuildKit { metadata })
     }
+
+    fn build<F>(&self, try_vendor: F) -> Result<(), ConfigurationError>
+    where
+        F: Fn(VendoredBuildContext) -> Result<(), ConfigurationError>,
+    {
+        match self.mode()? {
+            BuildKitMode::VendoredBuild => {
+                let vendored_source = self
+                    .metadata
+                    .vendored_source
+                    .as_ref()
+                    .ok_or_else(|| ConfigurationError::NoVendoredSourceSpecified)?;
+                let ctx = VendoredBuildContext::new(vendored_source);
+                try_vendor(ctx)
+            }
+            BuildKitMode::PkgConfig => {
+                let req = self
+                    .metadata
+                    .pkg_config
+                    .as_ref()
+                    .ok_or_else(|| ConfigurationError::NoPkgConfigRequirementSpecified)?;
+                try_pkg_config(req)
+            }
+            BuildKitMode::VcPkg => {
+                let req = self
+                    .metadata
+                    .vcpkg
+                    .as_ref()
+                    .ok_or_else(|| ConfigurationError::NoVcpkgRequirementSpecified)?;
+                try_vcpkg(req)
+            }
+        }
+    }
+
+    // TODO: ways for external build systems to override
+    fn mode(&self) -> Result<BuildKitMode, ConfigurationError> {
+        if matches!(self.metadata.default_mode, BuildKitMode::VendoredBuild) {
+            return Ok(BuildKitMode::VendoredBuild);
+        }
+        let target = std::env::var("TARGET").map_err(|e| ConfigurationError::NoTargetInEnv(e))?;
+        // TODO: should we relax it to `-windows-`?
+        // Some people seems to use vcpkg with mingw: https://www.reddit.com/r/cpp/comments/p1655e/comment/h8bly7v
+        //
+        // TODO: should we retry if vcpkg found nothing?
+        // curl-sys falls back to pkg_config when vcpkg failed.
+        // https://github.com/alexcrichton/curl-rust/blob/c01261310f13c85dc70d4e8a1ef87504662a1154/curl-sys/build.rs#L30-L37
+        if target.ends_with("-windows-msvc") {
+            Ok(BuildKitMode::VcPkg)
+        } else {
+            Ok(BuildKitMode::PkgConfig)
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -52,6 +104,18 @@ enum ConfigurationError {
     InvalidCargoMetadata(String),
     #[error("Failed to deserialize `package.metadata.buildkit`")]
     Json(#[from] serde_json::Error),
+    #[error("vendored mode is set but no vendored source specified")]
+    NoVendoredSourceSpecified,
+    #[error("pkg-config mode is set but no pkg-config requirement specified")]
+    NoPkgConfigRequirementSpecified,
+    #[error("vcpkg mode is set but no vcpkg requirement specified")]
+    NoVcpkgRequirementSpecified,
+    #[error("Did not find $TARGET in env")]
+    NoTargetInEnv(#[source] std::env::VarError),
+    #[error("vcpkg failed to probe")]
+    VcpkgError(#[from] vcpkg::Error),
+    #[error("pkg-config failed to probe")]
+    PkgConfigError(#[from] pkg_config::Error),
 }
 
 // This will represent the data that folks can specify within their Cargo.toml
@@ -64,7 +128,7 @@ struct BuildKitMetadata {
     default_mode: BuildKitMode,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone, Copy)]
 enum BuildKitMode {
     PkgConfig,
     VcPkg,
@@ -117,4 +181,26 @@ enum VendoredSource {
     SystemPath {
         path: Utf8PathBuf,
     },
+}
+
+#[derive(Debug)]
+pub struct VendoredBuildContext {
+    source_path: Utf8PathBuf,
+}
+
+impl VendoredBuildContext {
+    // TODO
+    fn new(source: &VendoredSource) -> VendoredBuildContext {
+        VendoredBuildContext {
+            source_path: Utf8PathBuf::new(),
+        }
+    }
+}
+
+fn try_vcpkg(req: &VcPkgRequirement) -> Result<(), ConfigurationError> {
+    todo!()
+}
+
+fn try_pkg_config(req: &PkgConfigRequirement) -> Result<(), ConfigurationError> {
+    todo!()
 }


### PR DESCRIPTION
Sketch out how lib probes look like.

Things to figure out in the future:

* Should we relax it to `-windows-`?
  Some people seems to use vcpkg with mingw: https://www.reddit.com/r/cpp/comments/p1655e/comment/h8bly7v
* Should we retry if vcpkg found nothing?
  curl-sys falls back to pkg_config when vcpkg failed.
https://github.com/alexcrichton/curl-rust/blob/c01261310f13c85dc70d4e8a1ef87504662a1154/curl-sys/build.rs#L30-L37
* Provide a way for external build system to override the buildkit `mode`.
