### PR TITLE
feat: implement pkg-config probe

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,9 @@ enum BuildKitMode {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 struct PkgConfigRequirement {
+    /// Library to probe. The value will be verbatimly passed to `pkg-config`.
+    ///
+    /// For example, libcurl will be `libcurl`.
     name: String,
     version_req: Option<PkgConfigVersionReq>,
 }
@@ -192,11 +195,16 @@ struct PkgConfigRequirement {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[serde(rename_all_fields = "kebab-case")]
+#[serde(untagged)]
 enum PkgConfigVersionReq {
+    /// `[min..max)` (or `min..max` in Rust notation).
     Range { min: String, max: String },
-    Min(String),
-    Max(String),
-    Exact(String),
+    /// At least the given version.
+    Min { min: String },
+    /// At no newer than the given version.
+    Max { max: String },
+    /// At exactly the given version.
+    Exact { exact: String },
 }
 
 #[derive(Debug, Deserialize)]
@@ -265,7 +273,37 @@ fn try_vcpkg(req: &VcpkgRequirement) -> Result<(), Error> {
     todo!()
 }
 
-/// Probe system libraries via the [`pkg-config`] crate.
+/// Probes system libraries via the [`pkg-config`] crate.
 fn try_pkg_config(req: &PkgConfigRequirement) -> Result<(), Error> {
-    todo!()
+    let name = req.name.as_str();
+    emit_no_vendor(name);
+    let mut config = pkg_config::Config::new();
+
+    if let Some(version_req) = &req.version_req {
+        match version_req {
+            PkgConfigVersionReq::Range { min, max } => {
+                config.range_version(min.as_str()..max.as_str());
+            }
+            PkgConfigVersionReq::Min { min } => {
+                config.range_version(min.as_str()..);
+            }
+            PkgConfigVersionReq::Max { max } => {
+                config.range_version(..=max.as_str());
+            }
+            PkgConfigVersionReq::Exact { exact } => {
+                config.exactly_version(&exact);
+            }
+        }
+    }
+
+    let lib = config.probe(&req.name).map_err(ErrorKind::PkgConfigError)?;
+    for include in &lib.include_paths {
+        println!("cargo:include={}", include.display());
+    }
+    Ok(())
+}
+
+fn emit_no_vendor(lib_name: &str) {
+    let normalized_name = lib_name.to_uppercase().replace("-", "_");
+    println!("cargo:rerun-if-env-changed={normalized_name}_NO_VENDOR");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,12 @@ impl BuildKit {
                     ErrorKind::InvalidCargoMetadata(format!(r#"packages.id = "{root_id}""#))
                 })?
         };
-        let metadata = serde_json::from_value(root_package.metadata).map_err(ErrorKind::Json)?;
-
+        let value = root_package
+            .metadata
+            .get("buildkit")
+            .ok_or_else(|| ErrorKind::InvalidCargoMetadata(format!("package.metadata.buildkit")))?
+            .clone();
+        let metadata = serde_json::from_value(value).map_err(ErrorKind::Json)?;
         Ok(BuildKit { metadata })
     }
 


### PR DESCRIPTION
This has tested against https://github.com/rust-lang/git2-rs/commit/c3454fe91b52147f1e9521f3658b6b2c432b64d7 with this patch:

```diff
diff --git a/libgit2-sys/Cargo.toml b/libgit2-sys/Cargo.toml
index 67eaf8d..2bbc27c 100644
--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -26,7 +26,7 @@ libssh2-sys = { version = "0.3.0", optional = true }
 libz-sys = { version = "1.1.0", default-features = false, features = ["libc"] }
 
 [build-dependencies]
-pkg-config = "0.3.15"
+buildkit = { git = "https://github.com/lovesegfault/buildkit", rev = "refs/pull/9/head" }
 cc = { version = "1.0.43", features = ['parallel'] }
 
 [target.'cfg(unix)'.dependencies]
@@ -39,3 +39,9 @@ ssh_key_from_memory = []
 vendored = []
 vendored-openssl = ["openssl-sys/vendored"]
 zlib-ng-compat = ["libz-sys/zlib-ng", "libssh2-sys?/zlib-ng-compat"]
+
+[package.metadata.buildkit]
+default-mode = "pkg-config"
+[package.metadata.buildkit.pkg-config]
+name = "libgit2"
+version-req = { min = "1.7.2", max = "1.8.0" }
diff --git a/libgit2-sys/build.rs b/libgit2-sys/build.rs
index 88fce00..caa9102 100644
--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -5,20 +5,15 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Tries to use system libgit2 and emits necessary build script instructions.
-fn try_system_libgit2() -> Result<pkg_config::Library, pkg_config::Error> {
-    let mut cfg = pkg_config::Config::new();
-    match cfg.range_version("1.7.2".."1.8.0").probe("libgit2") {
-        Ok(lib) => {
-            for include in &lib.include_paths {
-                println!("cargo:root={}", include.display());
-            }
-            Ok(lib)
-        }
-        Err(e) => {
-            println!("cargo:warning=failed to probe system libgit2: {e}");
-            Err(e)
+fn try_system_libgit2(buildkit: &buildkit::BuildKit) -> Result<(), buildkit::Error> {
+    let build = buildkit.build(|_| unreachable!("buildkit doesn't support fallback yet"));
+    if let Err(e) = build {
+        for line in e.to_string().lines() {
+            println!("cargo:warning={line}");
         }
+        return Err(e)
     }
+    Ok(())
 }
 
 fn main() {
@@ -34,8 +29,12 @@ fn main() {
     println!("cargo:rerun-if-env-changed=LIBGIT2_NO_VENDOR");
     let forced_no_vendor = env::var_os("LIBGIT2_NO_VENDOR").map_or(false, |s| s != "0");
 
+    let buildkit = match buildkit::BuildKit::from_metadata() {
+        Ok(buildkit) => buildkit,
+        Err(e) => panic!("{}", e),
+    };
     if forced_no_vendor {
-        if try_system_libgit2().is_err() {
+        if try_system_libgit2(&buildkit).is_err() {
             panic!(
                 "\
 The environment variable `LIBGIT2_NO_VENDOR` has been set but no compatible system libgit2 could be found.
@@ -43,14 +42,13 @@ The build is now aborting. To disable, unset the variable or use `LIBGIT2_NO_VEN
 ",
             );
         }
-
         // We've reached here, implying we're using system libgit2.
         return;
     }
 
     // To use zlib-ng in zlib-compat mode, we have to build libgit2 ourselves.
     let try_to_use_system_libgit2 = !vendored && !zlib_ng_compat;
-    if try_to_use_system_libgit2 && try_system_libgit2().is_ok() {
+    if try_to_use_system_libgit2 && try_system_libgit2(&buildkit).is_ok() {
         // using system libgit2 has worked
         return;
     }
@@ -236,7 +234,7 @@ The build is now aborting. To disable, unset the variable or use `LIBGIT2_NO_VEN
 
     cfg.compile("git2");
 
-    println!("cargo:root={}", dst.display());
+    println!("cargo:include={}", dst.display());
 
     if target.contains("windows") {
         println!("cargo:rustc-link-lib=winhttp");
diff --git a/systest/build.rs b/systest/build.rs
index bb34d9d..649b4c4 100644
--- a/systest/build.rs
+++ b/systest/build.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 fn main() {
     let mut cfg = ctest2::TestGenerator::new();
-    if let Some(root) = env::var_os("DEP_GIT2_ROOT") {
+    if let Some(root) = env::var_os("DEP_GIT2_INCLUDE") {
         cfg.include(PathBuf::from(root).join("include"));
     }
     cfg.header("git2.h")
```