### PR TITLE
feat: implement vcpkg probe

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,7 +270,15 @@ impl VendoredBuildContext {
 ///
 /// [ms-vcpkg]: https://github.com/microsoft/vcpkg
 fn try_vcpkg(req: &VcpkgRequirement) -> Result<(), Error> {
-    todo!()
+    let name = req.name.as_str();
+    emit_no_vendor(name);
+    let mut config = vcpkg::Config::new();
+    config.emit_includes(true);
+    for lib in &req.libs {
+        config.lib_names(&lib.lib_name, &lib.dll_name);
+    }
+    let _ = config.find_package(name).map_err(ErrorKind::VcpkgError)?;
+    Ok(())
 }
 
 /// Probes system libraries via the [`pkg-config`] crate.


### PR DESCRIPTION
There are several issues needed to figure out after this change:

* vcpkg for both MinGW and MSVC
* Should we fallback to vcpkg after pkg-config failed?

I don't have Windows machine now so merge this as-is.